### PR TITLE
JSON Remove trailiing comma from last object

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,6 @@ module.exports = (str, opts) => {
 			continue;
 		}
 	}
-
-	return ret + (insideComment ? strip(str.substr(offset)) : str.substr(offset));
+	ret = ret + (insideComment ? strip(str.substr(offset)) : str.substr(offset));
+	return ret.replace(/,(?=\s*?[}\]])/,'');
 };


### PR DESCRIPTION
```
var str=`
[  
   {  
      "ITEM2":{  
         "names":[  
            "nameB",
            "nameC"
         ]
      }
   },
]
}`
str.replace(/,(?=\s*?[}\]])/,'');
```